### PR TITLE
Fixed by skipping invalid CSV

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,9 @@ const App = () => {
         const nextShopList: Iemeshi.ShopData[] = []
         for (let i = 0; i < features.length; i++) {
           const feature = features[i] as Iemeshi.ShopData
+          if (!feature['経度'] || !feature['緯度'] || !feature['店名']) {
+            continue;
+          }
           const shop = {
             index: i,
             ...feature


### PR DESCRIPTION
CSV の編集中に緯度、軽度、店名情報がないとエラーが発生し、世界地図が表示される。
不正なデータは読み飛ばすように修正する。